### PR TITLE
Change rules for RuboCop.

### DIFF
--- a/gems/dependencies.yml
+++ b/gems/dependencies.yml
@@ -1,5 +1,7 @@
 bundler:
 
+rubocop:
+
 coveralls:
   gemfile:
     require: false
@@ -47,8 +49,6 @@ timers:
   gemspec:
   gemfile:
     github: celluloid/timers
-
-rubocop:
 
 rspec-log_split:
   gemfile:

--- a/gems/dependencies.yml
+++ b/gems/dependencies.yml
@@ -51,7 +51,8 @@ timers:
     github: celluloid/timers
 
 rspec-log_split:
+  version: "~> 0.1.2"
   gemfile:
-    github: "abstractive/rspec-log_split"
+    github: "abstractive/rspec-logsplit"
     branch: "master"
     require: false

--- a/rubocop/style.yml
+++ b/rubocop/style.yml
@@ -22,7 +22,7 @@ Style/SpaceAroundEqualsInParameterDefault:
 
 Style/SpaceInsideBlockBraces:
   Enabled: false
-  
+
 Style/AccessModifierIndentation:
   Enabled: false
 
@@ -40,7 +40,9 @@ Style/SpaceInsideHashLiteralBraces:
 
 Style/EmptyLinesAroundAccessModifier:
   Enabled: false
-  
+
 Style/RescueModifier:
   Enabled: false
-  
+
+Style/GlobalVars:
+  Enabled: false

--- a/rubocop/style.yml
+++ b/rubocop/style.yml
@@ -40,3 +40,7 @@ Style/SpaceInsideHashLiteralBraces:
 
 Style/EmptyLinesAroundAccessModifier:
   Enabled: false
+  
+Style/RescueModifier:
+  Enabled: false
+  


### PR DESCRIPTION
There are several times where we use `rescue nil` especially with `undef` on `def` or `define_method` calls, to suppress errors on MRI. Allow inline `rescue nil`.

There are several global variables in use as systemic behavioral modifiers. Allow global variables.

/cc: @niamster, @tarcieri