### PR TITLE
celluloid-supervision depends on 0.17.1 ??

### DIFF
--- a/gems/dependencies.yml
+++ b/gems/dependencies.yml
@@ -30,7 +30,7 @@ coveralls:
 
 celluloid:
   dependency: core
-  version: ">= 0.17.0"
+  version: ">= 0.17.1"
   gemfile:
     github: celluloid/celluloid
     branch: master


### PR DESCRIPTION
I would post this to celluloid-supervision, posting a PR to the gemspec noting celluloid-supervision's new dependency from celluloid 0.20.0 to 0.20.1, but in a surprising twist... I find its gemspec defined in another repo.  For good reasons I'm sure, gemspecs are very boring.

Not sure how, but today's (8/6/2015) release of celluloid-supervision version 0.20.1 broke our sidekiq.  We were pointing at celluloid 0.20.0, and getting missing constants.  Upgrading celluloid to 0.17.1 fixes it.  

I'm going to leave this off with a hit from today's pop culture icon, Avril Lavigne:

![giphy](https://cloud.githubusercontent.com/assets/148768/9124525/44d68c50-3c5d-11e5-8737-9c2c22a9c379.gif)
