### PR TITLE
Mark development dependencies as such...

### DIFF
--- a/gems/dependencies.yml
+++ b/gems/dependencies.yml
@@ -1,6 +1,11 @@
 bundler:
+  dependency: development
+
 nenv:
+  dependency: development
+
 dotenv:
+  dependency: development
 
 benchmark_suite:
   dependency: development
@@ -77,6 +82,7 @@ timers:
     github: celluloid/timers
 
 rspec-logsplit:
+  dependency: development
   version: ">= 0.1.2"
   gemfile:
     github: "abstractive/rspec-logsplit"


### PR DESCRIPTION
Avoids pulling down development depdencies for celluloid users.

Before:
```
# Gemfile.lock
...
  specs:
    celluloid (0.17.1.1)
      bundler
      celluloid-essentials
      celluloid-extras
      celluloid-fsm
      celluloid-pool
      celluloid-supervision
      dotenv
      nenv
      rspec-logsplit (>= 0.1.2)
      timers (~> 4.0.0)
...
```

After:
```
# Gemfile.lock
...
  specs:
    celluloid (0.17.5.pre)
      celluloid-essentials
      celluloid-extras
      celluloid-fsm
      celluloid-pool
      celluloid-supervision
      timers (~> 4.0.0)
...
```

As far as I can tell, this doesn't break anything: I ran cellulloid/celluloid specs with the culture submodule pointing locally to this change and the were all green. 

Thanks,