### PR TITLE
Updated Rubocop style - TrailingCommaInArguments

### DIFF
--- a/rubocop/style.yml
+++ b/rubocop/style.yml
@@ -26,7 +26,7 @@ Style/SpaceInsideBlockBraces:
 Style/AccessModifierIndentation:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: comma
 


### PR DESCRIPTION
Fixes the following issue when running Rubocop.
<img width="569" alt="screen shot 2016-03-15 at 6 04 49 am" src="https://cloud.githubusercontent.com/assets/3950603/13756422/f064dabc-ea73-11e5-9ed1-e0f8d2a27f60.png">
